### PR TITLE
Update TelegramBotHandler.php to support 7.4 also

### DIFF
--- a/src/TelegramBotHandler.php
+++ b/src/TelegramBotHandler.php
@@ -57,7 +57,7 @@ class TelegramBotHandler extends AbstractProcessingHandler implements HandlerInt
     public function __construct(
         string      $token,
         string      $chat_id,
-        string|null $topic_id = null,
+        ?string $topic_id = null,
                     $level = Logger::DEBUG,
         bool        $bubble = true,
                     $bot_api = 'https://api.telegram.org/bot',


### PR DESCRIPTION
as the lower php version cannot parse '|' to type strict, it's better to use '?'  to show the variable is null