### PR TITLE
Add Support for Dynamic Timeout in Telegram API Requests

### DIFF
--- a/src/SendJob.php
+++ b/src/SendJob.php
@@ -26,6 +26,7 @@ class SendJob implements ShouldQueue
         private string      $chatId,
         private string|null $topicId = null,
         private string|null $proxy = null,
+        private int         $timeout = 5,
     )
     {
     }
@@ -39,7 +40,7 @@ class SendJob implements ShouldQueue
             $httpClientOption['proxy'] = $this->proxy;
         }
 
-        $httpClientOption['timeout'] = 5;
+        $httpClientOption['timeout'] = $this->timeout;
 
         $params = [
             'text' => $this->message,

--- a/src/TelegramBotHandler.php
+++ b/src/TelegramBotHandler.php
@@ -53,6 +53,13 @@ class TelegramBotHandler extends AbstractProcessingHandler
     protected TopicDetector $topicDetector;
 
     /**
+     * Timeout for Telegram API requests in seconds.
+     *
+     * @var int
+     */
+    protected int $timeout;
+
+    /**
      * @param string $token Telegram bot access token provided by BotFather
      * @param string $channel Telegram channel name
      * @inheritDoc
@@ -66,7 +73,9 @@ class TelegramBotHandler extends AbstractProcessingHandler
                     $level = Logger::DEBUG,
         bool        $bubble = true,
         string      $bot_api = 'https://api.telegram.org/bot',
-        string|null $proxy = null)
+        string|null $proxy = null,
+        int         $timeout = 5
+    )
     {
         parent::__construct($level, $bubble);
 
@@ -78,6 +87,7 @@ class TelegramBotHandler extends AbstractProcessingHandler
         $this->level = $level;
         $this->bubble = $bubble;
         $this->proxy = $proxy;
+        $this->timeout = $timeout;
 
         $this->topicDetector = new TopicDetector($topics_level);
     }
@@ -127,9 +137,9 @@ class TelegramBotHandler extends AbstractProcessingHandler
         $message = $this->truncateTextToTelegramLimit($message);
 
         if (empty($this->queue)) {
-            dispatch_sync(new SendJob($url, $message, $chatId, $topicId, $this->proxy));
+            dispatch_sync(new SendJob($url, $message, $chatId, $topicId, $this->proxy, $this->timeout));
         } else {
-            dispatch(new SendJob($url, $message, $chatId, $topicId, $this->proxy))->onQueue($this->queue);
+            dispatch(new SendJob($url, $message, $chatId, $topicId, $this->proxy, $this->timeout))->onQueue($this->queue);
         }
     }
 


### PR DESCRIPTION
This PR adds support for a dynamic timeout value when making Telegram API requests. The default timeout is set to 5 seconds.

Why this is useful:
- Allows flexibility in handling slow or unstable network conditions.
- Helps mitigate issues related to request delays or timeout errors by adjusting the timeout value accordingly.

Usage example:

```php
'telegram' => [
            'driver' => 'monolog',
            'level' => 'debug',
            'handler' => TheCoder\MonologTelegram\TelegramBotHandler::class,
            'handler_with' => [
                'token' => env('LOG_TELEGRAM_BOT_TOKEN'),
                'chat_id' => env('LOG_TELEGRAM_CHAT_ID'),
                'topic_id' => env('LOG_TELEGRAM_TOPIC_ID', null),
                'bot_api' => env('LOG_TELEGRAM_BOT_API', 'https://api.telegram.org/bot'),
                'proxy' => env('LOG_TELEGRAM_BOT_PROXY', null),
                'queue' => env('LOG_TELEGRAM_QUEUE', null),
                'topics_level' => [
                    EmergencyAttribute::class => env('LOG_TELEGRAM_EMERGENCY_ATTRIBUTE_TOPIC_ID', null),
                    CriticalAttribute::class => env('LOG_TELEGRAM_CRITICAL_ATTRIBUTE_TOPIC_ID', null),
                    ImportantAttribute::class => env('LOG_TELEGRAM_IMPORTANT_ATTRIBUTE_TOPIC_ID', null),
                    DebugAttribute::class => env('LOG_TELEGRAM_DEBUG_ATTRIBUTE_TOPIC_ID', null),
                    InformationAttribute::class => env('LOG_TELEGRAM_INFORMATION_ATTRIBUTE_TOPIC_ID', null),
                    LowPriorityAttribute::class => env('LOG_TELEGRAM_LOWPRIORITY_ATTRIBUTE_TOPIC_ID', null),
                ],
                'timeout' => env('LOG_TELEGRAM_TIMEOUT', 5),
            ],
            'formatter' => TheCoder\MonologTelegram\TelegramFormatter::class,
            'formatter_with' => [
                'tags' => env('LOG_TELEGRAM_TAGS', null),
            ],
        ],
```